### PR TITLE
Add blog structure with list and post page skeletons

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page not found</title>
+  <script>
+    // GitHub Pages has no server-side routing, so /blog/posts/<slug> is served
+    // as a 404. Rewrite it to the real post template before rendering anything.
+    (function () {
+      var match = location.pathname.match(/^\/blog\/posts\/([^/]+)\/?$/);
+      if (match) {
+        location.replace('/blog/post.html?slug=' + encodeURIComponent(match[1]));
+      }
+    })();
+  </script>
+  <link rel="icon" href="/img/favicon.ico" />
+  <link rel="stylesheet" href="/dist/output.css" />
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans flex items-center justify-center min-h-screen">
+  <div class="text-center px-4">
+    <h1 class="text-3xl font-bold mb-2">Page not found</h1>
+    <p class="text-gray-500 dark:text-gray-400 mb-6">The page you're looking for doesn't exist.</p>
+    <a href="/index.html" class="text-primary-600 dark:text-primary-400 hover:underline">Back home</a>
+  </div>
+</body>
+</html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog · Leonardo H. Batista</title>
+  <meta name="description" content="Posts and articles by Leonardo H. Batista" />
+  <link rel="icon" href="/img/favicon.ico" />
+  <script>
+    if (localStorage.getItem('theme') === 'dark' ||
+        (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <link rel="stylesheet" href="/dist/output.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/dist/fa.min.css" />
+  <link rel="stylesheet" href="/dist/devicon.min.css" />
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans transition-colors duration-300">
+
+  <!-- NAV -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur border-b border-gray-200 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex items-center justify-between h-14">
+      <a href="/index.html" class="font-semibold text-primary-600 dark:text-primary-400 tracking-tight">leohbatista</a>
+      <nav class="flex items-center gap-1 sm:gap-2 text-sm font-medium">
+        <a href="/index.html"       class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Profile</a>
+        <a href="/curriculum.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Curriculum</a>
+        <a href="/content.html"     class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Content</a>
+        <a href="/blog/index.html"  class="px-3 py-1.5 rounded-md bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">Blog</a>
+        <button id="theme-toggle" aria-label="Toggle dark mode"
+          class="ml-2 p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+          <svg id="icon-sun" class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M12 3v1m0 16v1m8.66-9h-1M4.34 12h-1m15.07-6.07-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 5a7 7 0 100 14A7 7 0 0012 5z"/>
+          </svg>
+          <svg id="icon-moon" class="w-4 h-4 block dark:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+          </svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-5xl mx-auto px-4 sm:px-6 py-16">
+    <h1 class="text-3xl sm:text-4xl font-bold tracking-tight mb-8">Blog</h1>
+
+    <div id="post-list" class="grid gap-4 mb-8">
+      <p class="text-gray-400 dark:text-gray-600">Loading posts…</p>
+    </div>
+
+    <div id="pagination" class="flex items-center justify-center gap-4"></div>
+  </main>
+
+  <footer class="border-t border-gray-200 dark:border-gray-800 mt-16 py-8 text-center text-sm text-gray-400 dark:text-gray-600">
+    <p>© 2026 Leonardo H. Batista · Campinas, Brazil</p>
+  </footer>
+
+  <script>
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      const html = document.documentElement;
+      if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+      } else {
+        html.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+      }
+    });
+  </script>
+  <script src="js/list.js"></script>
+
+</body>
+</html>

--- a/blog/js/list.js
+++ b/blog/js/list.js
@@ -1,0 +1,51 @@
+const PAGE_SIZE = 5;
+
+function cardTemplate(post) {
+  return `
+    <a href="/blog/posts/${encodeURIComponent(post.slug)}"
+      class="group block p-5 rounded-xl border border-gray-200 dark:border-gray-800 hover:border-primary-400 dark:hover:border-primary-600 bg-gray-50 dark:bg-gray-900 hover:bg-primary-50 dark:hover:bg-primary-950 transition-all">
+      <h3 class="font-semibold text-lg mb-1 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">${post.title}</h3>
+      <p class="text-sm text-gray-500 dark:text-gray-400">${post.description}</p>
+    </a>`;
+}
+
+function renderPagination(page, totalPages) {
+  const el = document.getElementById('pagination');
+  if (totalPages <= 1) { el.innerHTML = ''; return; }
+
+  const prevDisabled = page <= 1;
+  const nextDisabled = page >= totalPages;
+
+  el.innerHTML = `
+    <a href="?page=${page - 1}" aria-disabled="${prevDisabled}"
+      class="px-3 py-1.5 rounded-md text-sm font-medium border border-gray-300 dark:border-gray-700 ${prevDisabled ? 'pointer-events-none opacity-40' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}">Previous</a>
+    <span class="text-sm text-gray-500 dark:text-gray-400">Page ${page} of ${totalPages}</span>
+    <a href="?page=${page + 1}" aria-disabled="${nextDisabled}"
+      class="px-3 py-1.5 rounded-md text-sm font-medium border border-gray-300 dark:border-gray-700 ${nextDisabled ? 'pointer-events-none opacity-40' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}">Next</a>`;
+}
+
+async function initBlogList() {
+  const container = document.getElementById('post-list');
+  const page = Math.max(1, parseInt(new URLSearchParams(location.search).get('page'), 10) || 1);
+
+  let posts;
+  try {
+    const res = await fetch('posts.json');
+    posts = await res.json();
+  } catch (err) {
+    container.innerHTML = '<p class="text-gray-500 dark:text-gray-400">Could not load posts.</p>';
+    return;
+  }
+
+  const totalPages = Math.max(1, Math.ceil(posts.length / PAGE_SIZE));
+  const start = (page - 1) * PAGE_SIZE;
+  const pagePosts = posts.slice(start, start + PAGE_SIZE);
+
+  container.innerHTML = pagePosts.length
+    ? pagePosts.map(cardTemplate).join('')
+    : '<p class="text-gray-500 dark:text-gray-400">No posts yet.</p>';
+
+  renderPagination(page, totalPages);
+}
+
+initBlogList();

--- a/blog/js/markdown.js
+++ b/blog/js/markdown.js
@@ -1,0 +1,96 @@
+// Minimal markdown + front-matter parsing, dependency-free by design.
+
+function escapeHtml(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function parseFrontMatter(raw) {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/);
+  if (!match) return { metadata: {}, body: raw };
+
+  const metadata = {};
+  match[1].split('\n').forEach((line) => {
+    const idx = line.indexOf(':');
+    if (idx === -1) return;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+    metadata[key] = value;
+  });
+
+  return { metadata, body: raw.slice(match[0].length) };
+}
+
+function renderInline(text) {
+  let html = escapeHtml(text);
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  return html;
+}
+
+function renderMarkdown(markdown) {
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+  const htmlParts = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim() === '') { i++; continue; }
+
+    if (line.startsWith('```')) {
+      const code = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        code.push(lines[i]);
+        i++;
+      }
+      i++; // skip closing fence
+      htmlParts.push(`<pre><code>${escapeHtml(code.join('\n'))}</code></pre>`);
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      const level = heading[1].length;
+      htmlParts.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    if (line.match(/^>\s?/)) {
+      const quote = [];
+      while (i < lines.length && lines[i].match(/^>\s?/)) {
+        quote.push(lines[i].replace(/^>\s?/, ''));
+        i++;
+      }
+      htmlParts.push(`<blockquote>${renderInline(quote.join(' '))}</blockquote>`);
+      continue;
+    }
+
+    if (line.match(/^[-*]\s+/)) {
+      const items = [];
+      while (i < lines.length && lines[i].match(/^[-*]\s+/)) {
+        items.push(`<li>${renderInline(lines[i].replace(/^[-*]\s+/, ''))}</li>`);
+        i++;
+      }
+      htmlParts.push(`<ul>${items.join('')}</ul>`);
+      continue;
+    }
+
+    const paragraph = [];
+    while (i < lines.length && lines[i].trim() !== '' && !lines[i].match(/^(#{1,6})\s+|^```|^[-*]\s+|^>\s?/)) {
+      paragraph.push(lines[i]);
+      i++;
+    }
+    htmlParts.push(`<p>${renderInline(paragraph.join(' '))}</p>`);
+  }
+
+  return htmlParts.join('\n');
+}

--- a/blog/js/post.js
+++ b/blog/js/post.js
@@ -1,0 +1,34 @@
+async function initBlogPost() {
+  const container = document.getElementById('post-content');
+  const slug = new URLSearchParams(location.search).get('slug');
+
+  if (!slug) {
+    container.innerHTML = '<p class="text-gray-500 dark:text-gray-400">No post specified.</p>';
+    return;
+  }
+
+  let raw;
+  try {
+    const res = await fetch(`posts/${encodeURIComponent(slug)}.md`);
+    if (!res.ok) throw new Error('not found');
+    raw = await res.text();
+  } catch (err) {
+    container.innerHTML = '<p class="text-gray-500 dark:text-gray-400">Post not found.</p>';
+    return;
+  }
+
+  const { metadata, body } = parseFrontMatter(raw);
+
+  if (metadata.title) document.title = `${metadata.title} · Blog`;
+
+  const dateLine = metadata.date
+    ? `<p class="text-sm text-gray-400 dark:text-gray-500 mb-8">${metadata.date}${metadata.author ? ' · ' + metadata.author : ''}</p>`
+    : '';
+
+  container.innerHTML = `
+    <h1 class="text-3xl sm:text-4xl font-bold tracking-tight mb-2">${metadata.title || slug}</h1>
+    ${dateLine}
+    <div class="prose prose-gray dark:prose-invert max-w-none">${renderMarkdown(body)}</div>`;
+}
+
+initBlogPost();

--- a/blog/post.html
+++ b/blog/post.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog · Leonardo H. Batista</title>
+  <link rel="icon" href="/img/favicon.ico" />
+  <script>
+    if (localStorage.getItem('theme') === 'dark' ||
+        (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
+  <link rel="stylesheet" href="/dist/output.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/dist/fa.min.css" />
+  <link rel="stylesheet" href="/dist/devicon.min.css" />
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 font-sans transition-colors duration-300">
+
+  <!-- NAV -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur border-b border-gray-200 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex items-center justify-between h-14">
+      <a href="/index.html" class="font-semibold text-primary-600 dark:text-primary-400 tracking-tight">leohbatista</a>
+      <nav class="flex items-center gap-1 sm:gap-2 text-sm font-medium">
+        <a href="/index.html"       class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Profile</a>
+        <a href="/curriculum.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Curriculum</a>
+        <a href="/content.html"     class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Content</a>
+        <a href="/blog/index.html"  class="px-3 py-1.5 rounded-md bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">Blog</a>
+        <button id="theme-toggle" aria-label="Toggle dark mode"
+          class="ml-2 p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+          <svg id="icon-sun" class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M12 3v1m0 16v1m8.66-9h-1M4.34 12h-1m15.07-6.07-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 5a7 7 0 100 14A7 7 0 0012 5z"/>
+          </svg>
+          <svg id="icon-moon" class="w-4 h-4 block dark:hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
+          </svg>
+        </button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 sm:px-6 py-16">
+    <a href="/blog/index.html" class="inline-flex items-center gap-1 text-sm text-primary-600 dark:text-primary-400 hover:underline mb-8">&larr; Back to blog</a>
+
+    <article id="post-content">
+      <p class="text-gray-400 dark:text-gray-600">Loading post…</p>
+    </article>
+  </main>
+
+  <footer class="border-t border-gray-200 dark:border-gray-800 mt-16 py-8 text-center text-sm text-gray-400 dark:text-gray-600">
+    <p>© 2026 Leonardo H. Batista · Campinas, Brazil</p>
+  </footer>
+
+  <script>
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      const html = document.documentElement;
+      if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+      } else {
+        html.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+      }
+    });
+  </script>
+  <script src="js/markdown.js"></script>
+  <script src="js/post.js"></script>
+
+</body>
+</html>

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -1,0 +1,7 @@
+[
+  {
+    "title": "Welcome to the Blog",
+    "description": "A quick introduction to this blog and how it's built — posts are plain markdown files loaded on demand.",
+    "slug": "welcome-to-the-blog"
+  }
+]

--- a/blog/posts.json
+++ b/blog/posts.json
@@ -3,5 +3,10 @@
     "title": "Welcome to the Blog",
     "description": "A quick introduction to this blog and how it's built — posts are plain markdown files loaded on demand.",
     "slug": "welcome-to-the-blog"
+  },
+  {
+    "title": "Lorem Ipsum Example",
+    "description": "A placeholder post demonstrating headings, lists and formatted text.",
+    "slug": "lorem-ipsum-example"
   }
 ]

--- a/blog/posts/lorem-ipsum-example.md
+++ b/blog/posts/lorem-ipsum-example.md
@@ -1,0 +1,38 @@
+---
+title: Lorem Ipsum Example
+date: 2026-07-22
+author: Leonardo H. Batista
+---
+
+# Lorem Ipsum Example
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+## Section One
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+in culpa qui officia deserunt mollit anim id est laborum.
+
+- Sed ut perspiciatis unde omnis iste natus error
+- Sit voluptatem accusantium doloremque laudantium
+- Totam rem aperiam, eaque ipsa quae ab illo inventore
+
+## Section Two
+
+Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+consectetur, adipisci velit. Some **bold text**, some *italic text*, and a
+bit of `inline code` for good measure.
+
+> Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
+> suscipit laboriosam.
+
+```
+Nisi ut aliquid ex ea commodi consequatur.
+```
+
+Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse
+quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo
+voluptas nulla pariatur.

--- a/blog/posts/welcome-to-the-blog.md
+++ b/blog/posts/welcome-to-the-blog.md
@@ -1,0 +1,23 @@
+---
+title: Welcome to the Blog
+date: 2026-07-22
+author: Leonardo H. Batista
+---
+
+# Welcome
+
+This is the first post. Content lives in a markdown file per post, named after
+its `slug`, and is fetched and rendered client-side when this page loads.
+
+## How it works
+
+- The list page reads `blog/posts.json` for the title, description and slug of each post.
+- Each entry links to `/blog/posts/<slug>`.
+- This page reads the `slug` from the URL, fetches `posts/<slug>.md`, strips the
+  metadata block above, and renders the rest as HTML.
+
+Basic **bold**, *italic* and `inline code` all work, along with [links](/index.html).
+
+```
+Code blocks work too.
+```

--- a/content.html
+++ b/content.html
@@ -27,6 +27,7 @@
         <a href="index.html"       class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Profile</a>
         <a href="curriculum.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Curriculum</a>
         <a href="content.html"     class="px-3 py-1.5 rounded-md bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">Content</a>
+        <a href="blog/index.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Blog</a>
         <button id="theme-toggle" aria-label="Toggle dark mode"
           class="ml-2 p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
           <svg class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/curriculum.html
+++ b/curriculum.html
@@ -27,6 +27,7 @@
         <a href="index.html"       class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Profile</a>
         <a href="curriculum.html"  class="px-3 py-1.5 rounded-md bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">Curriculum</a>
         <a href="content.html"     class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Content</a>
+        <a href="blog/index.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Blog</a>
         <button id="theme-toggle" aria-label="Toggle dark mode"
           class="ml-2 p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
           <svg class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <a href="index.html"       class="px-3 py-1.5 rounded-md bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300">Profile</a>
         <a href="curriculum.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Curriculum</a>
         <a href="content.html"     class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Content</a>
+        <a href="blog/index.html"  class="px-3 py-1.5 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">Blog</a>
         <button id="theme-toggle" aria-label="Toggle dark mode"
           class="ml-2 p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
           <svg id="icon-sun" class="w-4 h-4 hidden dark:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
Posts list lives in blog/posts.json (title, description, slug); post
bodies are markdown files in blog/posts/<slug>.md with a front-matter
metadata block, fetched and rendered client-side. Added a 404.html
redirect so /blog/posts/<slug> resolves to the post template on
GitHub Pages, and a Blog nav link across existing pages.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014kbvuKUwvNm39Xd1UPgtQ9